### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Fix a bug when peakrdl-regblock is pip installed with -e (editable). 

Using Python 3.11.

The error received is:
```
Collecting peakrdl-regblock (from -r /scratch/anookala/triglav_rtl_clean/util/socrates-base/python/peakrdl_requirements.txt (line 8))
  Cloning https://github.com/HEP-SoC/PeakRDL-regblock.git (to revision f1.0.1) to /localdata/tmp/anookala/tmp/pip-install-fr1a5s4r/peakrdl-regblock_9cd384c130c54d4ea4612279fb95f148
  Running command git clone --filter=blob:none --quiet https://github.com/HEP-SoC/PeakRDL-regblock.git /localdata/tmp/anookala/tmp/pip-install-fr1a5s4r/peakrdl-regblock_9cd384c130c54d4ea4612279fb95f148
  Resolved https://github.com/HEP-SoC/PeakRDL-regblock.git to commit 02726324552b467249e1edc6adcc6f81cd971b65
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [76 lines of output]
      toml section missing 'pyproject.toml does not contain a tool.setuptools_scm section'
      
   ```